### PR TITLE
fix the link being focused after click problem

### DIFF
--- a/js/grayscale.js
+++ b/js/grayscale.js
@@ -29,6 +29,12 @@ $('.navbar-collapse ul li a').click(function() {
     $('.navbar-toggle:visible').click();
 });
 
+// remove the focused state after click, otherwise bootstrap
+// bootstrap will still highlight the link
+$("a").mouseup(function(){
+    $(this).blur();
+})
+
 // Google Maps Scripts
 // When the window has finished loading create our google map below
 google.maps.event.addDomListener(window, 'load', init);


### PR DESCRIPTION
If you click any link in nav bar, and then scroll away, that clicked link will stay highlighted